### PR TITLE
Fix dependency issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- Promote phoenix_live_view dependency to all envs. See #3
+
 ## 0.2.1
 
 ### Changed

--- a/mix.exs
+++ b/mix.exs
@@ -17,7 +17,7 @@ defmodule Skipper.MixProject do
   def project do
     [
       app: :skipper,
-      version: "0.2.1",
+      version: "0.2.2-rc1",
       elixir: "~> 1.12",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/mix.exs
+++ b/mix.exs
@@ -42,7 +42,7 @@ defmodule Skipper.MixProject do
     [
       {:ex_doc, ">= 0.0.0", only: :dev, runtime: false},
       {:floki, "~> 0.34", only: :test},
-      {:phoenix_live_view, "~> 0.18", only: [:dev, :test]}
+      {:phoenix_live_view, "~> 0.18"}
     ]
   end
 end

--- a/test/skipper/live_view_test_test.exs
+++ b/test/skipper/live_view_test_test.exs
@@ -1,12 +1,12 @@
 defmodule Skipper.LiveViewTestTest do
   use ExUnit.Case, async: true
-  doctest Skipper.LiveViewTest
 
   import Phoenix.ConnTest
 
   @endpoint Test.Support.Endpoint
 
   use Skipper.LiveViewTest
+  doctest Skipper.LiveViewTest
 
   setup do
     conn = build_conn() |> Plug.Test.init_test_session(%{})


### PR DESCRIPTION
❓ I expected this to work as a dev/test dependency since apps using this project would have the LiveView dep. But maybe that's not how Hex works?

Here's the error I have been getting in the downstream project:
```
== Compilation error in file lib/skipper/live_view_test.ex ==
** (CompileError) lib/skipper/live_view_test.ex:26: module Phoenix.LiveViewTest is not loaded and could not be found

could not compile dependency :skipper, "mix compile" failed. Errors may have been logged above. You can recompile this dependency with "mix deps.compile skipper", update it with "mix deps.update skipper" or clean it with "mix deps.clean skipper"
```

My concern is that locking down this as an actual project dependency may cause issues for downstream users of it... Maybe we'll just have to tweak the version restriction over time to accomomdate uses.