### PR TITLE
Add support for a "normal" redirect that returns {:ok, Plug.Conn} tuple

### DIFF
--- a/lib/skipper/live_view_test.ex
+++ b/lib/skipper/live_view_test.ex
@@ -27,6 +27,7 @@ defmodule Skipper.LiveViewTest do
 
   defmacro __using__([]) do
     quote do
+      alias Plug.Conn
       import Phoenix.LiveViewTest
       import unquote(__MODULE__)
 
@@ -36,6 +37,10 @@ defmodule Skipper.LiveViewTest do
 
       defp handle_redirects(conn, nil, {:ok, view, html}) do
         {conn, {:ok, view, html}}
+      end
+
+      defp handle_redirects(conn, _, {:ok, %Plug.Conn{} = new_conn}) do
+        {new_conn, live(new_conn)}
       end
 
       defp handle_redirects(conn, _view, redirect) do

--- a/test/skipper/live_view_test_test.exs
+++ b/test/skipper/live_view_test_test.exs
@@ -50,6 +50,8 @@ defmodule Skipper.LiveViewTestTest do
       |> assert_visible("Home")
       |> click("[phx-click=redirect]")
       |> assert_visible("Home")
+      |> click("#normallink")
+      |> assert_visible("Home")
     end
 
     test "forms", %{conn: conn} do

--- a/test/support/live.ex
+++ b/test/support/live.ex
@@ -6,6 +6,7 @@ defmodule Test.Support.Live do
     ~H"""
     <html>
       <a class="home" phx-click="home">Home</a>
+      <a id="normallink" href="/home">Normal home</a>
       <span id="link-1"><a phx-click="link-1">Edit Link</a></span>
       <div class="lolwat">yes</div>
       <form id="widget-form" phx-change="changed" phx-submit="submitted">

--- a/test/support/router.ex
+++ b/test/support/router.ex
@@ -5,6 +5,7 @@ defmodule Test.Support.Router do
 
   live("/", Test.Support.Live)
   live("/redirect", Redirect)
+  live("/home", Test.Support.Live)
 end
 
 defmodule Redirect do


### PR DESCRIPTION
Love the library, found this missing while using it in my project.